### PR TITLE
Hotfix for the version import

### DIFF
--- a/python/ics/cobraOps/__init__.py
+++ b/python/ics/cobraOps/__init__.py
@@ -1,0 +1,1 @@
+from .version import __version__


### PR DESCRIPTION
This pull request introduces a small change to the `python/ics/cobraOps/__init__.py` file. The change imports the `__version__` variable from the `version` module, which helps expose the package version at the top level.

This is for the backward compatibility and you can import version like (cf. `netflow`)

```python
from ics.cobraOps import __version__ as cobraOpsVersion
```

(sorry for making too many hotfixes)